### PR TITLE
Fixed bug with stackable resources decrement

### DIFF
--- a/engine/pkg/game/engine/mixins/container_object/remove_items_kinds.go
+++ b/engine/pkg/game/engine/mixins/container_object/remove_items_kinds.go
@@ -35,9 +35,11 @@ func (cont *ContainerObject) RemoveItemsKinds(e entity.IEngine, player *entity.P
 				if itemStackable {
 					item.Properties()["amount"] = item.Properties()["amount"].(float64) - itemsCounts[itemKind]
 					e.SendGameObjectUpdate(item, "update_object")
-					itemsCounts[itemKind] = 0.0
 					if item.Properties()["amount"].(float64) != 0.0 {
 						performRemove = false
+						itemsCounts[itemKind] = 0.0
+					} else {
+						itemsCounts[itemKind] = 1.0 // will be decreased during object removing
 					}
 				}
 				if performRemove {


### PR DESCRIPTION
# Bug

When a player buys smth with the exact amount of stackable resources, it won't receive items bought due to an error in the **RemoveItemsKinds** function.

> It decreases the amount of resources and sets the number of items left to be removed `itemCounts[itemKind]` to 0. However, if the player spends all the resources, the function will perform removing the resource object and will decrease `itemCounts[itemKind]` one more time, which causes a problem.

# Expected

The player receives the item bought without any issues.